### PR TITLE
Add composer.json for Composer-based projects

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {  
-  "name": "shawnconn/logintoboggan",
+  "name": "newzeal/logintoboggan",
   "type": "drupal-module",
   "description": "",
   "keywords": ["Drupal"],

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,15 @@
+{  
+  "name": "shawnconn/logintoboggan",
+  "type": "drupal-module",
+  "description": "",
+  "keywords": ["Drupal"],
+  "license": "",
+  "homepage": "",
+  "minimum-stability": "dev",
+  "authors": [  
+  ],
+  "support": {  
+  },
+  "require": {  
+  }
+}


### PR DESCRIPTION
This PR adds a skeleton composer.json so the project can be referenced via [vcs repo](https://getcomposer.org/doc/05-repositories.md#loading-a-package-from-a-vcs-repository) (`"newzeal/logintoboggan": "dev-master"`) until the d.o project is updated with a [D8 port](https://www.drupal.org/node/2605570) where `drupal/logintoboggan` can be referenced.

